### PR TITLE
Add static prototype with dummy inbox

### DIFF
--- a/MARKET_RESEARCH_AND_DESIGN.md
+++ b/MARKET_RESEARCH_AND_DESIGN.md
@@ -1,0 +1,33 @@
+# Market Research and Design Plan for MaskInbox
+
+## Product Need and Demand
+- Temporary email services let users avoid spam and protect privacy when signing up for services.
+- Established competitors such as Temp-Mail, 10MinuteMail, and Guerrilla Mail receive millions of visits monthly, showing sustained demand.
+- Search trends historically show consistent interest in keywords like "temp mail" and "temporary email," indicating ongoing user need.
+
+## Target Markets
+- High internet usage and privacy awareness make regions like India, the United States, Indonesia, Brazil, and Russia strong targets.
+- Users typically include privacy-conscious individuals, developers testing sign-up flows, and people avoiding promotional emails.
+
+## Monetization Potential
+- **Freemium model:** free basic inboxes, with paid plans for custom domains, longer retention, or multiple addresses.
+- **Advertising:** unobtrusive ads or affiliate links in the inbox interface.
+- **Developer API:** subscription access for automated testing or bulk inbox creation.
+
+## Marketing Strategy
+- Focus on SEO for terms such as "temporary email" and "disposable inbox."
+- Publish blog posts on privacy, spam prevention, and best practices to drive organic traffic.
+- Launch on communities like Product Hunt and relevant privacy forums to reach early adopters.
+- Provide open-source client libraries or browser extensions to encourage sharing.
+
+## Design Guidelines
+- Minimal, responsive layout centered around the generated email address and inbox.
+- Clear call-to-action buttons for copying the address, refreshing the inbox, and deleting messages.
+- Display inbox messages in a simple list with subject, sender, and time.
+- Offer dark and light modes with neutral backgrounds and a single accent color for interactive elements.
+- Include visible privacy policy and data deletion controls to build trust.
+
+## Technical Considerations
+- Serverless architecture or managed services (e.g., Supabase) for scaling and storage.
+- Automatic message expiration to limit storage costs and improve privacy.
+- Rate limiting and abuse prevention to protect infrastructure.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # MaskInbox
+
+Prototype for a privacy-friendly temporary email service.
+
+See [MARKET_RESEARCH_AND_DESIGN.md](MARKET_RESEARCH_AND_DESIGN.md) for market research and design plan.
+
+A static HTML prototype is provided in `index.html` with dummy data to experiment with the inbox layout.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MaskInbox - Temporary Email</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>MaskInbox</h1>
+  </header>
+  <main>
+    <section id="address">
+      <h2>Your temporary email address</h2>
+      <div class="address-box">
+        <span id="temp-address">demo@maskinbox.example</span>
+        <button id="copy-btn">Copy</button>
+      </div>
+    </section>
+    <section id="inbox">
+      <h2>Inbox</h2>
+      <ul id="message-list">
+        <li data-message="Welcome to MaskInbox!">From: Support<br />Subject: Welcome</li>
+        <li data-message="This is a sample email body for demonstration.">From: Example<br />Subject: Dummy Message</li>
+      </ul>
+      <div id="message-content">
+        <p>Select a message to preview.</p>
+      </div>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,17 @@
+document.getElementById('copy-btn').addEventListener('click', function () {
+  const addr = document.getElementById('temp-address').textContent;
+  navigator.clipboard.writeText(addr).then(() => {
+    const original = this.textContent;
+    this.textContent = 'Copied!';
+    setTimeout(() => {
+      this.textContent = original;
+    }, 1000);
+  });
+});
+
+document.querySelectorAll('#message-list li').forEach((item) => {
+  item.addEventListener('click', () => {
+    const content = item.getAttribute('data-message');
+    document.getElementById('message-content').textContent = content;
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,49 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background-color: #f5f5f5;
+  color: #333;
+}
+header {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+main {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: #fff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+.address-box {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #eee;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+.address-box button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+#message-list {
+  list-style: none;
+  padding: 0;
+}
+#message-list li {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ddd;
+  cursor: pointer;
+}
+#message-list li:hover {
+  background-color: #f0f0f0;
+}
+#message-content {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  min-height: 100px;
+}


### PR DESCRIPTION
## Summary
- add minimal HTML/CSS/JS prototype showing a temporary email address and sample inbox
- document the presence of the static prototype in the README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9c8d8f1c832f97b8c6236f48b884